### PR TITLE
parallely running hibernate bundles for a tenant

### DIFF
--- a/src/main/java/io/appform/dropwizard/sharding/MultiTenantDBShardingBundleBase.java
+++ b/src/main/java/io/appform/dropwizard/sharding/MultiTenantDBShardingBundleBase.java
@@ -36,7 +36,6 @@ import io.appform.dropwizard.sharding.healthcheck.HealthCheckManager;
 import io.appform.dropwizard.sharding.sharding.ShardBlacklistingStore;
 import io.appform.dropwizard.sharding.sharding.ShardManager;
 import io.dropwizard.Configuration;
-import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.db.PooledDataSourceFactory;
 import io.dropwizard.hibernate.AbstractDAO;
 import io.dropwizard.hibernate.HibernateBundle;
@@ -52,6 +51,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -97,62 +99,70 @@ public abstract class MultiTenantDBShardingBundleBase<T extends Configuration> e
 
   @Override
   public void run(T configuration, Environment environment) {
-    val tenantedConfig = getConfig(configuration);
-    tenantedConfig.getTenants().forEach((tenantId, shardConfig) -> {
-      var blacklistingStore = getBlacklistingStore();
-      var shardManager = createShardManager(shardConfig.getShards().size(), blacklistingStore);
-      this.shardManagers.put(tenantId, shardManager);
-      val shardInfoProvider = new ShardInfoProvider(tenantId);
-      shardInfoProviders.put(tenantId, shardInfoProvider);
-      var healthCheckManager = new HealthCheckManager(tenantId, shardInfoProvider,
-          blacklistingStore,
-          shardManager);
-      healthCheckManagers.put(tenantId, healthCheckManager);
-      //Encryption Support through jasypt-hibernate5
-      var shardingOption = shardConfig.getShardingOptions();
-      shardingOption =
-          Objects.nonNull(shardingOption) ? shardingOption : new ShardingBundleOptions();
-      List<HibernateBundle<T>> shardedBundle = IntStream.range(0, shardConfig.getShards().size())
-          .mapToObj(
-              shard ->
-                  new HibernateBundle<T>(initialisedEntities, new SessionFactoryFactory()) {
-                    @Override
-                    protected String name() {
-                      return shardInfoProvider.shardName(shard);
-                    }
+    ExecutorService executorService = Executors.newCachedThreadPool();
+    try {
+      val tenantedConfig = getConfig(configuration);
+      tenantedConfig.getTenants().forEach((tenantId, shardConfig) -> {
+        var blacklistingStore = getBlacklistingStore();
+        var shardManager = createShardManager(shardConfig.getShards().size(), blacklistingStore);
+        this.shardManagers.put(tenantId, shardManager);
+        val shardInfoProvider = new ShardInfoProvider(tenantId);
+        shardInfoProviders.put(tenantId, shardInfoProvider);
+        var healthCheckManager = new HealthCheckManager(tenantId, shardInfoProvider,
+                blacklistingStore,
+                shardManager);
+        healthCheckManagers.put(tenantId, healthCheckManager);
+        //Encryption Support through jasypt-hibernate5
+        var shardingOption = shardConfig.getShardingOptions();
+        shardingOption =
+                Objects.nonNull(shardingOption) ? shardingOption : new ShardingBundleOptions();
+        List<HibernateBundle<T>> shardedBundle = IntStream.range(0, shardConfig.getShards().size())
+                .mapToObj(
+                        shard ->
+                                new HibernateBundle<T>(initialisedEntities, new SessionFactoryFactory()) {
+                                  @Override
+                                  protected String name() {
+                                    return shardInfoProvider.shardName(shard);
+                                  }
 
-                    @Override
-                    public PooledDataSourceFactory getDataSourceFactory(T t) {
-                      return shardConfig.getShards().get(shard);
-                    }
-                  }).collect(Collectors.toList());
-      shardedBundle.forEach(hibernateBundle -> {
-        try {
-          hibernateBundle.run(configuration, environment);
-        } catch (Exception e) {
-          log.error("Error initializing db sharding bundle for tenant {}", tenantId, e);
-          throw new RuntimeException(e);
+                                  @Override
+                                  public PooledDataSourceFactory getDataSourceFactory(T t) {
+                                    return shardConfig.getShards().get(shard);
+                                  }
+                                }).collect(Collectors.toList());
+
+        CompletableFuture.allOf(shardedBundle.stream()
+                .map(hibernateBundle -> CompletableFuture.runAsync(() -> {
+                  try {
+                    hibernateBundle.run(configuration, environment);
+                  } catch (Exception e) {
+                    log.error("Error initializing db sharding bundle for tenant {}", tenantId, e);
+                    throw new RuntimeException(e);
+                  }
+                }, executorService)).toArray(CompletableFuture[]::new)).join();
+        this.shardBundles.put(tenantId, shardedBundle);
+        val sessionFactory = shardedBundle.stream().map(HibernateBundle::getSessionFactory)
+                .collect(Collectors.toList());
+        sessionFactory.forEach(factory -> factory.getProperties().put("tenant.id", tenantId));
+        if (shardingOption.isEncryptionSupportEnabled()) {
+          Preconditions.checkArgument(shardingOption.getEncryptionIv().length() == 16,
+                  "Encryption IV Should be 16 bytes long");
+          registerStringEncryptor(tenantId, shardingOption);
+          registerBigIntegerEncryptor(tenantId, shardingOption);
+          registerBigDecimalEncryptor(tenantId, shardingOption);
+          registerByteEncryptor(tenantId, shardingOption);
         }
+        this.sessionFactories.put(tenantId, sessionFactory);
+        this.shardingOptions.put(tenantId, shardingOption);
+        healthCheckManager.manageHealthChecks(shardConfig.getBlacklist(), environment);
+        setupObservers(shardConfig.getMetricConfig(), environment.metrics());
+        environment.admin().addTask(new BlacklistShardTask(tenantId, shardManager));
+        environment.admin().addTask(new UnblacklistShardTask(tenantId, shardManager));
       });
-      this.shardBundles.put(tenantId, shardedBundle);
-      val sessionFactory = shardedBundle.stream().map(HibernateBundle::getSessionFactory)
-          .collect(Collectors.toList());
-      sessionFactory.forEach(factory -> factory.getProperties().put("tenant.id", tenantId));
-      if (shardingOption.isEncryptionSupportEnabled()) {
-        Preconditions.checkArgument(shardingOption.getEncryptionIv().length() == 16,
-            "Encryption IV Should be 16 bytes long");
-        registerStringEncryptor(tenantId, shardingOption);
-        registerBigIntegerEncryptor(tenantId, shardingOption);
-        registerBigDecimalEncryptor(tenantId, shardingOption);
-        registerByteEncryptor(tenantId, shardingOption);
-      }
-      this.sessionFactories.put(tenantId, sessionFactory);
-      this.shardingOptions.put(tenantId, shardingOption);
-      healthCheckManager.manageHealthChecks(shardConfig.getBlacklist(), environment);
-      setupObservers(shardConfig.getMetricConfig(), environment.metrics());
-      environment.admin().addTask(new BlacklistShardTask(tenantId, shardManager));
-      environment.admin().addTask(new UnblacklistShardTask(tenantId, shardManager));
-    });
+    }
+    finally {
+      executorService.shutdown();
+    }
   }
 
   @Override
@@ -161,8 +171,6 @@ public abstract class MultiTenantDBShardingBundleBase<T extends Configuration> e
     healthCheckManagers.values().forEach(healthCheckManager -> {
       bootstrap.getHealthCheckRegistry().addListener(healthCheckManager);
     });
-    shardBundles.values().forEach(
-        hibernateBundle -> bootstrap.addBundle((ConfiguredBundle) hibernateBundle));
   }
 
   @VisibleForTesting


### PR DESCRIPTION


---



 **DeputyDev generated PR summary:** 



---



 **Size L:** This PR changes include 120 lines and should take approximately 1-3 hours to review



---

The pull request enables parallel execution of Hibernate bundles for each tenant in a multi-tenant application. Here's a summary of what the PR changes:

1. **Parallel Execution**: The main change is the introduction of `CompletableFuture` and `ExecutorService` to run the initialization of Hibernate bundles in parallel for each tenant. This change is intended to improve performance by leveraging concurrency.

2. **Executor Service**: An `ExecutorService` is created using `Executors.newCachedThreadPool()`, which allows for dynamic thread management based on workload.

3. **CompletableFuture**: Instead of iterating over each Hibernate bundle and running them sequentially, the code now uses `CompletableFuture.runAsync()` to run each bundle asynchronously. This is done for all the bundles of a tenant, and `CompletableFuture.allOf(...).join()` is used to wait for all bundles to complete.

4. **Error Handling**: Errors during the initialization of any bundle are logged, and a `RuntimeException` is thrown, similar to the previous implementation, but now done within the asynchronous context.

5. **Resource Management**: Finally, the `ExecutorService` is properly shut down in the `finally` block to ensure that resources are released once the initialization is complete.

Here's the relevant corrected code snippet for parallel execution:
```java
ExecutorService executorService = Executors.newCachedThreadPool();
try {
    val tenantedConfig = getConfig(configuration);
    tenantedConfig.getTenants().forEach((tenantId, shardConfig) -> {
        var blacklistingStore = getBlacklistingStore();
        var shardManager = createShardManager(shardConfig.getShards().size(), blacklistingStore);
        this.shardManagers.put(tenantId, shardManager);
        val shardInfoProvider = new ShardInfoProvider(tenantId);
        shardInfoProviders.put(tenantId, shardInfoProvider);
        var healthCheckManager = new HealthCheckManager(tenantId, shardInfoProvider,
                blacklistingStore,
                shardManager);
        healthCheckManagers.put(tenantId, healthCheckManager);
        var shardingOption = shardConfig.getShardingOptions();
        shardingOption =
                Objects.nonNull(shardingOption) ? shardingOption : new ShardingBundleOptions();
        List<HibernateBundle<T>> shardedBundle = IntStream.range(0, shardConfig.getShards().size())
                .mapToObj(
                        shard ->
                                new HibernateBundle<T>(initialisedEntities, new SessionFactoryFactory()) {
                                    @Override
                                    protected String name() {
                                        return shardInfoProvider.shardName(shard);
                                    }

                                    @Override
                                    public PooledDataSourceFactory getDataSourceFactory(T t) {
                                        return shardConfig.getShards().get(shard);
                                    }
                                }).collect(Collectors.toList());

        CompletableFuture.allOf(shardedBundle.stream()
                .map(hibernateBundle -> CompletableFuture.runAsync(() -> {
                    try {
                        hibernateBundle.run(configuration, environment);
                    } catch (Exception e) {
                        log.error("Error initializing db sharding bundle for tenant {}", tenantId, e);
                        throw new RuntimeException(e);
                    }
                }, executorService)).toArray(CompletableFuture[]::new)).join();
        this.shardBundles.put(tenantId, shardedBundle);
        val sessionFactory = shardedBundle.stream().map(HibernateBundle::getSessionFactory)
                .collect(Collectors.toList());
        sessionFactory.forEach(factory -> factory.getProperties().put("tenant.id", tenantId));
        if (shardingOption.isEncryptionSupportEnabled()) {
            Preconditions.checkArgument(shardingOption.getEncryptionIv().length() == 16,
                    "Encryption IV Should be 16 bytes long");
            registerStringEncryptor(tenantId, shardingOption);
            registerBigIntegerEncryptor(tenantId, shardingOption);
            registerBigDecimalEncryptor(tenantId, shardingOption);
            registerByteEncryptor(tenantId, shardingOption);
        }
        this.sessionFactories.put(tenantId, sessionFactory);
        this.shardingOptions.put(tenantId, shardingOption);
        healthCheckManager.manageHealthChecks(shardConfig.getBlacklist(), environment);
        setupObservers(shardConfig.getMetricConfig(), environment.metrics());
        environment.admin().addTask(new BlacklistShardTask(tenantId, shardManager));
        environment.admin().addTask(new UnblacklistShardTask(tenantId, shardManager));
    });
}
finally {
    executorService.shutdown();
}
```

This PR effectively makes the initialization process more efficient by leveraging parallel processing, which can be particularly beneficial in environments with multiple tenants and shards.

---

DeputyDev generated PR summary until 9be3bd17a3d10dbf2630faa25960b03839a9a358